### PR TITLE
Add_生活用品一覧基準数一括登録機能、Fix_ヘッダーリンク、フッターレイアウト

### DIFF
--- a/app/controllers/public/livingwares_controller.rb
+++ b/app/controllers/public/livingwares_controller.rb
@@ -1,11 +1,11 @@
 class Public::LivingwaresController < ApplicationController
   before_action :authenticate_customer!, except: [:top]
-  
+
   def index
     @livingwares = current_customer.group.livingwares.order(:category_id)
     @categories = current_customer.group.categories
   end
-  
+
   def log
     @livingware = Livingware.new(livingware_params)
     @categories = current_customer.group.categories
@@ -13,10 +13,11 @@ class Public::LivingwaresController < ApplicationController
     params[:livingware].select {|k, v| v[:id].present? }.each do |id, param|
       livingware = current_customer.group.livingwares.find(id)
       livingware.amount = param[:amount].to_i
+      livingware.amount_standard = param[:amount_standard].to_i
       @livingwares.push livingware
     end
   end
-  
+
   def show
     @livingware = Livingware.find(params[:id])
     @categories = current_customer.group.categories
@@ -26,7 +27,7 @@ class Public::LivingwaresController < ApplicationController
     @livingware = Livingware.new
     @categories = current_customer.group.categories
   end
-  
+
   def create
     @livingware = Livingware.new(livingware_params)
     @livingware.group_id = current_customer.group_id
@@ -42,7 +43,7 @@ class Public::LivingwaresController < ApplicationController
     @livingware = Livingware.find(params[:id])
     @categories = current_customer.group.categories
   end
-  
+
   def update
     @livingware = Livingware.find(params[:id])
     if @livingware.update(livingware_params)
@@ -52,28 +53,28 @@ class Public::LivingwaresController < ApplicationController
       render :edit
     end
   end
-  
+
   def update_all
     params[:livingware].each do |id, param|
       livingware = current_customer.group.livingwares.find(id)
       buy_amount = livingware.amount_standard - param[:amount].to_i
-      livingware.update(buy_amount: buy_amount, amount: param[:amount].to_i)
+      livingware.update(buy_amount: buy_amount, amount: param[:amount].to_i, amount_standard: param[:amount_standard].to_i)
     end
     redirect_to livingwares_path
   end
-  
+
   def destroy
     @livingware = Livingware.find(params[:id])
     @livingware.destroy
     redirect_to livingwares_path
   end
-  
-  
-  
+
+
+
   private
 
   def livingware_params
     params.require(:livingware).permit(:category_id,:group_id,:name,:note,:amount,:amount_standard,:livingware_image)
   end
-  
+
 end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -48,11 +48,7 @@ footer {
   height: 60px;
   text-align: center;
   padding: 20px 0;
-  margin: 200px auto 0px;
-}
-
-.footer-text{
-
+  margin: 180px auto 0px;
 }
 
 .td-margin {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,10 +27,10 @@
           　<ul class="navbar-nav ml-auto">
               <% if customer_signed_in? %>
                 <li class="nav-item  active mx-3">
-                  <%= link_to "買い物リスト", to_buy_lists_path,class:"text-dark font-weight-bold" %>
+                  <%= link_to "買い物リスト", to_buy_lists_path,class:"text-dark font-weight-bold", data: {"turbolinks" => false} %>
                 </li>
                 <li class="nav-item mx-3">
-                  <%= link_to "生活用品", livingwares_path,class:"text-dark font-weight-bold" %>
+                  <%= link_to "生活用品", livingwares_path,class:"text-dark font-weight-bold", data: {"turbolinks" => false} %>
                 </li>
                 <li class="nav-item mx-3">
                   <%= link_to "カテゴリー", categories_path,class:"text-dark font-weight-bold" %>

--- a/app/views/public/livingwares/index.html.erb
+++ b/app/views/public/livingwares/index.html.erb
@@ -44,7 +44,7 @@
                   <%= f.select :amount, *[0..100] %>
                 </td>
                 <td>
-                  <%=livingware.amount_standard.to_s(:delimited) %>
+                  <%= f.select :amount_standard, *[0..100] %>
                 </td>
                 <td>
                   <%=livingware.note %>

--- a/app/views/public/livingwares/log.html.erb
+++ b/app/views/public/livingwares/log.html.erb
@@ -1,4 +1,4 @@
-<div class="container"> 
+<div class="container">
   <div class = "row">
     <%= image_tag 'illustrain02-cat19.png', :size => '110x110' %>
     <h3><span class="font-weight-bold center">生活用品変更一覧</span></h3>
@@ -17,7 +17,7 @@
           <th>備考</th>
         </tr>
       </thead>
-  
+
       <tbody class="table-borderless">
         <% @livingwares.each do |livingware| %>
           <%= fb.fields_for "livingware[]", livingware do |f| %>
@@ -34,6 +34,7 @@
                 <%=livingware.amount.to_s(:delimited) %>
               </td>
               <td>
+                <%= f.hidden_field :amount_standard, value: livingware.amount_standard %>
                 <%=livingware.amount_standard.to_s(:delimited) %>
               </td>
               <td>
@@ -44,7 +45,7 @@
         <% end %>
       </tbody>
     </table>
-    
+
     <div align="center">
     <%= fb.submit '変更を確定する' ,class:"btn btn-stitch-orange" %>
     </div>


### PR DESCRIPTION
①機能追加
・生活用品一覧基準数一括登録機能

②修正
・ヘッダーリンクの生活用品・買い物リストにturbolinks無効に修正(各一覧画面のボタンのJavaScriptが本番環境で作動しなかったため)
・フッターレイアウト余白を減少