### PR TITLE
Add_他ユーザー作成の生活用品・カテゴリーの編集・削除不可機能

### DIFF
--- a/app/controllers/public/categories_controller.rb
+++ b/app/controllers/public/categories_controller.rb
@@ -19,6 +19,11 @@ class Public::CategoriesController < ApplicationController
 
   def edit
     @category = Category.find(params[:id])
+    if @category.group_id == current_customer.group_id
+      render :edit
+    else
+      redirect_to categories_path
+    end
   end
 
   def update
@@ -32,8 +37,12 @@ class Public::CategoriesController < ApplicationController
 
   def destroy
     @category = Category.find(params[:id])
-    @category.destroy
-    redirect_to categories_path
+    if @category.group_id == current_customer.group_id
+      @category.destroy
+      redirect_to categories_path
+    else
+      redirect_to categories_path
+    end
   end
 
   private

--- a/app/controllers/public/livingwares_controller.rb
+++ b/app/controllers/public/livingwares_controller.rb
@@ -21,6 +21,11 @@ class Public::LivingwaresController < ApplicationController
   def show
     @livingware = Livingware.find(params[:id])
     @categories = current_customer.group.categories
+    if @livingware.group_id == current_customer.group_id
+      render :show
+    else
+      redirect_to livingwares_path
+    end
   end
 
   def new
@@ -42,6 +47,11 @@ class Public::LivingwaresController < ApplicationController
   def edit
     @livingware = Livingware.find(params[:id])
     @categories = current_customer.group.categories
+    if @livingware.group_id == current_customer.group_id
+      render :edit
+    else
+      redirect_to livingwares_path
+    end
   end
 
   def update
@@ -65,8 +75,12 @@ class Public::LivingwaresController < ApplicationController
 
   def destroy
     @livingware = Livingware.find(params[:id])
-    @livingware.destroy
-    redirect_to livingwares_path
+    if @livingware.group_id == current_customer.group_id
+      @livingware.destroy
+      redirect_to livingwares_path
+    else
+      redirect_to livingwares_path
+    end
   end
 
 


### PR DESCRIPTION
会員側
・生活用品、カテゴリーが他ユーザーから編集・削除不可にするよう、設定(一覧画面に移動)
・生活用品詳細が他ユーザーからアクセス不可にするよう、設定(一覧画面に移動)